### PR TITLE
Feature link with urns

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,12 @@ const baseMap = {
   'FI-ASTERI-N': 'FIN11'
 };
 
+const urnBaseMap = {
+  'FIN11': 'URN:NBN:fi:au:cn:'
+};
+
+const urnResolverPrefix = 'http://urn.fi/';
+
 const bibRules = MarcPunctuation.readPunctuationRulesFromJSON(require('@natlibfi/melinda-marc-record-utils/dist/punctuation/bib-punctuation.json'));
 const authRules = MarcPunctuation.readPunctuationRulesFromJSON(require('@natlibfi/melinda-marc-record-utils/dist/punctuation/auth-punctuation.json'));
 
@@ -61,6 +67,8 @@ const authSyncServiceOptions = {
   agentRecordBase: 'FIN11',
   noOperation,
   baseMap,
+  urnBaseMap,
+  urnResolverPrefix,
   logger,
   punctuationRulesForAuthRecord: authRules,
   punctuationRulesForBibRecord: bibRules
@@ -68,6 +76,8 @@ const authSyncServiceOptions = {
 const bibSyncServiceOptions = {
   noOperationBibChange,
   baseMap,
+  urnBaseMap,
+  urnResolverPrefix,
   logger,
   punctuationRulesForBibRecord: bibRules
 };

--- a/lib/auth-record-sync.js
+++ b/lib/auth-record-sync.js
@@ -39,7 +39,10 @@ function create(alephRecordService, alephFindService, options) {
 
   const logger = _.get(options, 'logger', DEFAULT_LOGGER);
   const reverseBaseMap = Object.keys(options.baseMap).reduce((acc, key) => _.set(acc, options.baseMap[key], key), {});
+  const urnBaseMap = options.urnBaseMap;  
+  const urnResolverPrefix = options.urnResolverPrefix;
   const recentChangesManager = utils.RecentChangesManager(RECENT_CHANGE_COOLDOWN_MS);
+
 
   async function handleAuthChange(change) {
     const changeId = utils.randomString();
@@ -82,13 +85,15 @@ function create(alephRecordService, alephFindService, options) {
 
         debug(`[${changeId}] checking and maybe resetting authorized portion from bib record fields. Multiple fields may link to same authority.`);
         const query = `(${reverseBaseMap[change.library]})${change.recordId}`;
-        
+	const urnQuery=createUrnQuery(change,options);  
+	const urnQuery2=createUrnQueryPadded(change,options);  
+
         const fixedRecord = new MarcRecord(bibRecord);
 
         debug(`[${changeId}] Updating fields in ${bibRecordBase} / ${bibId} with ‡0${query}`);
         fixedRecord.fields = bibRecord.fields.map(field => {
           if (field.subfields === undefined) return field;
-          if (!hasSubfield('0', query)(field)) return field;
+          if (!hasSubfield('0', query)(field) && !hasSubfield('0', urnQuery)(field) && !hasSubfield('0', urnQuery2)(field)) return field;
 
           debug(`[${changeId}] Field before updateAuthorizedPortion and fixPunctuationFromBibField: ${RecordUtils.fieldToString(field)}`);
           const updatedField = MarcAuthorizedPortion.updateAuthorizedPortion(MarcAuthorizedPortion.RecordType.BIB, field, authorizedPortion);
@@ -151,10 +156,14 @@ function create(alephRecordService, alephFindService, options) {
         debug(`[${changeId}] checking and maybe resetting authrozied portion from linked auth record fields`);
         const fixedRecord = MarcRecord.clone(linkedAuthRecord);
         const query = `(${reverseBaseMap[change.library]})${change.recordId}`;
-      
+    
+	const urnQuery = createUrnQuery(change,options);
+        const urnQuery2 = createUrnQueryPadded(change,options);
+
+
         fixedRecord.fields = fixedRecord.fields.map(field => {
-          if (field.subfields === undefined) return field;
-          if (!hasSubfield('0', query)(field)) return field;
+	  if (field.subfields === undefined) return field;
+          if (!hasSubfield('0', query)(field) && !hasSubfield('0', urnQuery)(field) && !hasSubfield('0', urnQuery2)(field)) return field;
 
           const updatedField = MarcAuthorizedPortion.updateAuthorizedPortion(MarcAuthorizedPortion.RecordType.AUTH, field, authorizedPortion);
           fixPunctuationFromAuthField(updatedField);
@@ -186,12 +195,34 @@ function create(alephRecordService, alephFindService, options) {
   };
 }
 
+
 function hasSubfield(code, value) {
   return (field) => {
     return field.subfields.some(subfield => subfield.code === code && subfield.value === value);
   };
 }
 
+function createUrnQuery(change,options) {
+    const urnBaseMap = options.urnBaseMap;  
+    const urnResolverPrefix = options.urnResolverPrefix;
+    const urnQuery = `${urnResolverPrefix}${urnBaseMap[change.library]}${change.recordId}`;
+    return urnQuery;
+
+}
+
+function createUrnQueryPadded(change,options) {
+    const urnBaseMap = options.urnBaseMap;  
+    const urnResolverPrefix = options.urnResolverPrefix;
+    const recordId = change.recordId;
+    const paddedRecordId = _.padStart(recordId, 9, '0');
+    const urnQuery = `${urnResolverPrefix}${urnBaseMap[change.library]}${paddedRecordId}`;
+    return urnQuery;
+
+}
+
+
 module.exports = {
-  create
+  create,
+  createUrnQuery,
+  createUrnQueryPadded
 };

--- a/lib/auth-record-sync.spec.js
+++ b/lib/auth-record-sync.spec.js
@@ -28,6 +28,99 @@ const path = require('path');
 const bibRules = MarcPunctuation.readPunctuationRulesFromJSON(require('@natlibfi/melinda-marc-record-utils/dist/punctuation/bib-punctuation.json'));
 const authRules = MarcPunctuation.readPunctuationRulesFromJSON(require('@natlibfi/melinda-marc-record-utils/dist/punctuation/auth-punctuation.json'));
 
+const createUrnQuery = AuthRecordSyncService.createUrnQuery;
+const createUrnQueryPadded = AuthRecordSyncService.createUrnQueryPadded;
+
+describe('CreateUrnQuery', () => {
+
+    const baseMap = {
+      'TST01': 'TST01',
+      'TST10': 'TST10'
+    };
+
+   const urnBaseMap = {
+      'TST10': 'URN:NBN:fi:au:cn:'
+    };
+
+   const urnResolverPrefix = 'http://urn.fi/';
+
+    logger = { log: sinon.spy() };
+
+    const options = {
+      bibRecordBase: 'TST01',
+      agentRecordBase: 'TST10',
+      baseMap,
+      urnBaseMap,
+      urnResolverPrefix,
+      punctuationRulesForBibRecord: bibRules,
+      punctuationRulesForAuthRecord: authRules,
+      logger
+    };
+
+    const fakeChange = {
+        recordId: '90001',
+        library: 'TST10'
+    };
+
+ 
+   it('should create URN query correctly from change data and options', () => {
+
+
+       const query =   createUrnQuery(fakeChange,options);
+
+       expect(query).to.equal('http://urn.fi/URN:NBN:fi:au:cn:90001');
+
+   });
+
+
+
+});
+
+describe('CreateUrnQueryPadded', () => {
+
+    const baseMap = {
+      'TST01': 'TST01',
+      'TST10': 'TST10'
+    };
+
+   const urnBaseMap = {
+      'TST10': 'URN:NBN:fi:au:cn:'
+    };
+
+   const urnResolverPrefix = 'http://urn.fi/';
+
+    logger = { log: sinon.spy() };
+
+    const options = {
+      bibRecordBase: 'TST01',
+      agentRecordBase: 'TST10',
+      baseMap,
+      urnBaseMap,
+      urnResolverPrefix,
+      punctuationRulesForBibRecord: bibRules,
+      punctuationRulesForAuthRecord: authRules,
+      logger
+    };
+
+    const fakeChange = {
+        recordId: '90001',
+        library: 'TST10'
+    };
+
+ 
+   it('should create padded URN query correctly from change data and options', () => {
+
+
+       const query =   createUrnQueryPadded(fakeChange,options);
+
+       expect(query).to.equal('http://urn.fi/URN:NBN:fi:au:cn:000090001');
+
+   });
+
+
+
+});
+
 describe('AuthRecordSyncService', () => {
 
   let recordServiceStub;
@@ -55,6 +148,12 @@ describe('AuthRecordSyncService', () => {
       'TST01': 'TST01',
       'TST10': 'TST10'
     };
+ 
+   const urnBaseMap = {
+      'TST10': 'URN:NBN:fi:au:cn:'
+    };
+
+   const urnResolverPrefix = 'http://urn.fi/';
 
     logger = { log: sinon.spy() };
 
@@ -62,6 +161,8 @@ describe('AuthRecordSyncService', () => {
       bibRecordBase: 'TST01',
       agentRecordBase: 'TST10',
       baseMap,
+      urnBaseMap,
+      urnResolverPrefix,
       punctuationRulesForBibRecord: bibRules,
       punctuationRulesForAuthRecord: authRules,
       logger
@@ -79,6 +180,7 @@ describe('AuthRecordSyncService', () => {
       recordServiceStub.loadRecord.withArgs('TST10', '90001').resolves(fakeAuthRecord);
       findServiceStub.findLinkedAgentRecords.withArgs('TST01', '90001').resolves(['00001']);
     });
+
     
     it('should not save the record if it has not changed', async () => {
 
@@ -120,6 +222,33 @@ describe('AuthRecordSyncService', () => {
       expect(RecordUtils.fieldToString(record.getFields('700')[0])).to.equal('700    ‡aAakkula, Immo,‡tcontent.‡0(TST10)90001');
 
     });
+
+
+    it('should copy the name from the authority record and update the bib record fields linked with matching URN with it', async () => {
+
+      const fakeChange = {
+        recordId: '90001',
+        library: 'TST10'
+      };
+
+      fakeBibRecord.appendField(RecordUtils.stringToField('100    ‡aAakkula, I,‡tcontent‡0http://urn.fi/URN:NBN:fi:au:cn:000090001'));
+      fakeBibRecord.appendField(RecordUtils.stringToField('700    ‡aAakkula, I,‡tcontent‡0http://urn.fi/URN:NBN:fi:au:cn:90001'));
+      fakeAuthRecord.appendField(RecordUtils.stringToField('100    ‡aAakkula, Immo,‡tcontent'));
+
+      await recordSyncService.handleAuthChange(fakeChange);
+
+      expect(recordServiceStub.saveRecord.callCount).to.equal(1, 'SaveRecord was not called');
+
+      const [base, recordId, record] = recordServiceStub.saveRecord.getCall(0).args;
+      expect(base).to.equal('TST01');
+      expect(recordId).to.equal('00001');
+
+      expect(RecordUtils.fieldToString(record.getFields('100')[0])).to.equal('100    ‡aAakkula, Immo,‡tcontent.‡0http://urn.fi/URN:NBN:fi:au:cn:000090001');
+      expect(RecordUtils.fieldToString(record.getFields('700')[0])).to.equal('700    ‡aAakkula, Immo,‡tcontent.‡0http://urn.fi/URN:NBN:fi:au:cn:90001');
+
+
+    });
+
 
     it('should handle case when there are multiple 0 subfields with different bases', async () => {
 
@@ -311,6 +440,21 @@ describe('AuthRecordSyncService', () => {
  
       expect(RecordUtils.fieldToString(record.getFields('500')[0])).to.equal('500    ‡aAakkula, Immo,‡d1934-1992‡0(TST10)90001');
     });
+
+    it('should copy the name from the authority record and update the linked record fields (linked with URNs) with it', async () => {
+
+      fakeAuthRecord.appendField(RecordUtils.stringToField('100    ‡aAakkula, Immo,‡d1934-1992‡0(TST10)90001'));
+      fakeLinkedAuthRecord.appendField(RecordUtils.stringToField('500    ‡aAakkula, I.,‡0http://urn.fi/URN:NBN:fi:au:cn:000090001'));
+
+      await recordSyncService.handleAuthChange(fakeChange);
+
+      expect(recordServiceStub.saveRecord.callCount).to.equal(1, 'SaveRecord was not called');
+      const [, , record] = recordServiceStub.saveRecord.getCall(0).args;
+ 
+      expect(RecordUtils.fieldToString(record.getFields('500')[0])).to.equal('500    ‡aAakkula, Immo,‡d1934-1992‡0http://urn.fi/URN:NBN:fi:au:cn:000090001');
+    });
+
+
 
     it('should copy the name and tag if it changes', async () => {
 

--- a/lib/bib-record-sync.js
+++ b/lib/bib-record-sync.js
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */const debug = require('debug')('bib-record-sync');
+ */
+const debug = require('debug')('bib-record-sync');
 const MarcRecord = require('marc-record-js');
 const _ = require('lodash');
 const utils = require('./utils');
@@ -63,7 +64,7 @@ function create(alephRecordService, alephFindService, options) {
 
         let links = [];
         try {
-          links = authorityRecordLinkSubfields.map(field => parseAuthorityRecordLink(field.value));
+          links = authorityRecordLinkSubfields.map(field => parseAuthorityRecordLinkGlobal(field.value,options));
         } catch(error) {
           logger.log('warn', `[${changeId}]`, error.message);
         }
@@ -148,22 +149,47 @@ function create(alephRecordService, alephFindService, options) {
     }
   }
 
-  function parseAuthorityRecordLink(authorityRecordLink) {
-
-    const match = /^\((.*)\)(\d+)$/.exec(authorityRecordLink);
-    if (match) {
-      const [,base,recordId] = match;
-      return { base, recordId };
-    }
-
-    throw new Error(`Invalid format in subfield 0: ${authorityRecordLink}`);    
-  }
-
   return {
     handleBibChange
   };
 }
 
+function parseAuthorityRecordLinkGlobal(authorityRecordLink,options) {
+
+    const match = /^\((.*)\)(\d+)$/.exec(authorityRecordLink);
+    if (match) {
+	const [,base,recordId] = match;
+	return { base, recordId };
+    }
+
+
+    const urnRegexp = RegExp("^"+options.urnResolverPrefix+"(.*:)(.*)$");
+    const urn = urnRegexp.exec(authorityRecordLink);
+
+    if (urn) {
+
+	const [,prefix, id]=urn;
+	const urnBase = _.invert(options.urnBaseMap)[prefix];
+
+	if (typeof urnBase !== 'undefined' && urnBase !== null) {
+	    return {  'base': urnBase, 'recordId': id };
+	}
+	else {
+	    throw new Error(`Found non-mapped URN in: ${authorityRecordLink}. ${prefix}  ${id} ${urnBase}`);
+	}
+    }    
+
+    const url = /^http:\/\//.exec(authorityRecordLink);
+    if (url) {
+
+	throw new Error(`Invalid format (url) in subfield 0: ${authorityRecordLink}. Not matching known URN pattern: ${options.urnResolverPrefix}`);
+    }    
+
+    throw new Error(`Invalid format in subfield 0: ${authorityRecordLink}`);
+}
+
+
 module.exports = {
-  create
+  create,
+  parseAuthorityRecordLinkGlobal
 };

--- a/lib/bib-record-sync.spec.js
+++ b/lib/bib-record-sync.spec.js
@@ -11,8 +11,9 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- */const chai = require('chai');
+ * limitations under the License. 
+*/
+const chai = require('chai');
 const expect = chai.expect;
 const sinon = require('sinon');
 const MarcRecord = require('marc-record-js');
@@ -24,12 +25,98 @@ const MarcPunctuation = require('@natlibfi/melinda-marc-record-utils/dist/punctu
 
 const bibRules = MarcPunctuation.readPunctuationRulesFromJSON(require('@natlibfi/melinda-marc-record-utils/dist/punctuation/bib-punctuation.json'));
 
+const parseAuthorityLinkGlobal = BibRecordSyncService.parseAuthorityRecordLinkGlobal;
+
+describe('parseAuthorityLinkGlobal', function() {
+
+
+    const baseMap = {
+    'TST01': 'TST01',
+    'TST10': 'TST10',
+  };
+
+    const urnBaseMap = {
+      'TST10': 'URN:NBN:fi:au:cn:'
+    };
+
+   const urnResolverPrefix = 'http://urn.fi/';
+
+    const options = {
+      baseMap,
+      urnBaseMap,
+      urnResolverPrefix,
+      noOperation: false,
+      noOperationBibChange: false,
+      punctuationRulesForBibRecord: bibRules
+    };
+
+
+   it('should parse Aleph-ID correctly', () => {
+
+       const link =   parseAuthorityLinkGlobal("(FIN11)000123456",options);
+
+       expect(link.base).to.equal('FIN11');       
+       expect(link.recordId).to.equal('000123456');       
+
+   });
+
+   it('should parse isni correctly', () => {
+
+       const link =   parseAuthorityLinkGlobal("(isni)000123456",options);
+
+       expect(link.base).to.equal('isni');       
+       expect(link.recordId).to.equal('000123456');       
+
+   });
+
+   it('should skip non-mapped URNS', () => {
+
+       expect(function () {
+	   parseAuthorityLinkGlobal("http://urn.fi/URN:ISBN:fi:au:cn:123456",options);
+       }).to.throw(Error);
+
+   });
+
+   it('should skip URNS with no mapped resolver', () => {
+
+       expect(function () {
+	   parseAuthorityLinkGlobal("URN:ISBN:fi:au:cn:123456",options);
+       }).to.throw(Error);
+
+   });
+
+   it('should parse URN correctly', () => {
+
+       const link =   parseAuthorityLinkGlobal("http://urn.fi/URN:NBN:fi:au:cn:123456",options);
+       const link2 =   parseAuthorityLinkGlobal("http://urn.fi/URN:NBN:fi:au:cn:000123456",options);
+       const link3 =   parseAuthorityLinkGlobal("http://urn.fi/URN:NBN:fi:au:cn:123456A",options);
+
+       expect(link.base).to.equal('TST10');       
+       expect(link.recordId).to.equal('123456');       
+
+       expect(link2.base).to.equal('TST10');       
+       expect(link2.recordId).to.equal('000123456');       
+
+       expect(link3.base).to.equal('TST10');       
+       expect(link3.recordId).to.equal('123456A');       
+
+   });
+
+});
+
+
 describe('BibRecordSyncService', () => {
 
   const baseMap = {
     'TST01': 'TST01',
     'TST10': 'TST10',
   };
+
+    const urnBaseMap = {
+      'TST10': 'URN:NBN:fi:au:cn:'
+    };
+
+  const urnResolverPrefix = 'http://urn.fi/';
 
   let recordServiceStub;
   let findServiceStub;
@@ -51,6 +138,8 @@ describe('BibRecordSyncService', () => {
 
     const options = {
       baseMap,
+      urnBaseMap,
+      urnResolverPrefix,
       noOperation: false,
       noOperationBibChange: false,
       punctuationRulesForBibRecord: bibRules
@@ -58,6 +147,8 @@ describe('BibRecordSyncService', () => {
 
     const optionsNoOp = {
       baseMap,
+      urnBaseMap,
+      urnResolverPrefix,
       noOperation: false,
       noOperationBibChange: true,
       punctuationRulesForBibRecord: bibRules
@@ -89,7 +180,6 @@ describe('BibRecordSyncService', () => {
     expect(recordServiceStub.saveRecord.callCount).to.equal(0, 'SaveRecord was called');
 
   });
-
 
 
 
@@ -137,18 +227,41 @@ describe('BibRecordSyncService', () => {
 
   });
 
-  it('should handle 110 fields', async () => {
+  it('should skip field if link subfield is unparseable', async () => {
 
     const fakeChange = {
       recordId: '00001',
       library: 'TST01'
     };
 
-    fakeBibRecord.appendField(RecordUtils.stringToField('110    ‡aAakkula-K.,‡0(TST10)90001'));
+    fakeBibRecord.appendField(RecordUtils.stringToField('100    ‡aAakkula, I,‡tcontent‡0TST1090001,'));
+    fakeBibRecord.appendField(RecordUtils.stringToField('100    ‡aAakkula, I,‡tcontent'));
+    fakeAuthRecord.appendField(RecordUtils.stringToField('100    ‡aAakkula, Immo,‡tcontent'));
+
+    recordServiceStub.loadRecord.withArgs('TST01', '00001').resolves(fakeBibRecord);
+    recordServiceStub.loadRecord.withArgs('TST10', '90001').resolves(fakeAuthRecord);
+
+    await recordSyncService.handleBibChange(fakeChange);
+    
+    expect(recordServiceStub.saveRecord.callCount).to.equal(0, 'SaveRecord was called');
+    
+  });
+
+
+  it('should handle linking by URNs', async () => {
+
+    const fakeChange = {
+      recordId: '00001',
+      library: 'TST01'
+    };
+
+    fakeBibRecord.appendField(RecordUtils.stringToField('110    ‡aAakkula-K.,‡0http://urn.fi/URN:NBN:fi:au:cn:90001'));
+    fakeBibRecord.appendField(RecordUtils.stringToField('710    ‡aAakkula-K.,‡0http://urn.fi/URN:NBN:fi:au:cn:000090001'));
     fakeAuthRecord.appendField(RecordUtils.stringToField('110    ‡aAakkula-Kerho'));
 
     recordServiceStub.loadRecord.withArgs('TST01', '00001').resolves(fakeBibRecord);
     recordServiceStub.loadRecord.withArgs('TST10', '90001').resolves(fakeAuthRecord);
+    recordServiceStub.loadRecord.withArgs('TST10', '000090001').resolves(fakeAuthRecord);
 
     await recordSyncService.handleBibChange(fakeChange);
 
@@ -158,9 +271,11 @@ describe('BibRecordSyncService', () => {
     expect(base).to.equal('TST01');
     expect(recordId).to.equal('00001');
 
-    expect(RecordUtils.fieldToString(record.getFields('110')[0])).to.equal('110    ‡aAakkula-Kerho.‡0(TST10)90001');
+    expect(RecordUtils.fieldToString(record.getFields('110')[0])).to.equal('110    ‡aAakkula-Kerho.‡0http://urn.fi/URN:NBN:fi:au:cn:90001');
+    expect(RecordUtils.fieldToString(record.getFields('710')[0])).to.equal('710    ‡aAakkula-Kerho.‡0http://urn.fi/URN:NBN:fi:au:cn:000090001');
 
   });
+
 
   it('should copy any names from multiple authority records', async () => {
 
@@ -284,7 +399,6 @@ describe('BibRecordSyncService', () => {
     });
     
   });
-
 
   it('should change bib record authorized portion tag to match the one in the authority record', async () => {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,16 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -70,6 +80,153 @@
           "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
         }
       }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.3",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -110,6 +267,25 @@
         "type-detect": "4.0.7"
       }
     },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -131,6 +307,16 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+    },
+    "core-js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "csv-parse": {
       "version": "1.2.0",
@@ -157,6 +343,14 @@
       "dev": true,
       "requires": {
         "type-detect": "4.0.7"
+      }
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "2.0.1"
       }
     },
     "diff": {
@@ -189,8 +383,12 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "eyes": {
       "version": "0.1.8",
@@ -238,6 +436,11 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
@@ -260,6 +463,14 @@
       "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
       "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk="
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -271,6 +482,15 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -290,6 +510,22 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "invariant": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -315,6 +551,21 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "just-extend": {
       "version": "1.1.27",
@@ -344,6 +595,14 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
       "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
     },
     "marc-record-js": {
       "version": "0.3.2",
@@ -388,14 +647,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -496,6 +753,11 @@
         "abbrev": "1.1.1"
       }
     },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -511,6 +773,16 @@
       "requires": {
         "nan": "2.5.1"
       }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -532,15 +804,42 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+    },
+    "rewire": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-3.0.2.tgz",
+      "integrity": "sha512-ejkkt3qYnsQ38ifc9llAAzuHiGM7kR8N5/mL3aHWgmWwet0OMFcmJB8aTsMV2PBHCWxNVTLCeRfBpEa8X2+1fw==",
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0"
+      }
     },
     "samsam": {
       "version": "1.3.0",
@@ -579,6 +878,24 @@
         }
       }
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
     "sprintf": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
@@ -588,6 +905,14 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "supports-color": {
       "version": "4.4.0",
@@ -603,6 +928,16 @@
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "type-detect": {
       "version": "4.0.7",


### PR DESCRIPTION
Possibility to use URNs as authority links in (bib and aut) subfields $0 in addition to record controlnumbers prefixed with ISIL/Aleph lib.

